### PR TITLE
Initial draft-ietf-acme-ari Implementation

### DIFF
--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -79,7 +79,7 @@ func (c *CertificateService) GetRenewalInfo(certID string) (*http.Response, erro
 		return nil, ErrNoARI
 	}
 	if certID == "" {
-		return nil, errors.New("renewalInfo[post]: 'certID' cannot be empty")
+		return nil, errors.New("renewalInfo[get]: 'certID' cannot be empty")
 	}
 	return c.core.HTTPClient.Get(c.core.GetDirectory().RenewalInfo + "/" + certID)
 }

--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -61,6 +61,30 @@ func (c *CertificateService) Revoke(req acme.RevokeCertMessage) error {
 	return err
 }
 
+// GetRenewalInfo GETs renewal information for a certificate from the
+// renewalInfo endpoint. This is used to determine if a certificate needs to be
+// renewed.
+func (c *CertificateService) GetRenewalInfo(certID string) (*http.Response, error) {
+	if certID == "" {
+		return nil, errors.New("renewalInfo[post]: 'certID' cannot be empty")
+	}
+	return c.core.HTTPClient.Get(c.core.GetDirectory().RenewalInfo + "/" + certID)
+}
+
+// PostRenewalInfo POSTs updated renewal information for a certificate to the
+// renewalInfo endpoint. This is used to indicate that a certificate has been
+// renewed.
+func (c *CertificateService) UpdateRenewalInfo(req acme.RenewalInfoUpdateRequest) (*http.Response, error) {
+	if req.CertID == "" {
+		return nil, errors.New("renewalInfo[post]: 'certID' cannot be empty")
+	}
+
+	if !req.Replaced {
+		return nil, errors.New("renewalInfo[post]: 'replaced' cannot be false")
+	}
+	return c.core.post(c.core.GetDirectory().RenewalInfo, req, nil)
+}
+
 // get Returns the certificate and the "up" link.
 func (c *CertificateService) get(certURL string, bundle bool) (*acme.RawCertificate, http.Header, error) {
 	if certURL == "" {

--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -61,10 +61,23 @@ func (c *CertificateService) Revoke(req acme.RevokeCertMessage) error {
 	return err
 }
 
+// ErrNoARI is returned when the server does not advertise a renewal info
+// endpoint.
+var ErrNoARI = errors.New("renewalInfo[get/post]: server does not advertise a renewal info endpoint")
+
 // GetRenewalInfo GETs renewal information for a certificate from the
 // renewalInfo endpoint. This is used to determine if a certificate needs to be
 // renewed.
+//
+// Note: this endpoint is part of a draft specification, not all ACME servers
+// will implement it. This method will return api.ErrNoARI if the server does
+// not advertise a renewal info endpoint.
+//
+// https://datatracker.ietf.org/doc/draft-ietf-acme-ari
 func (c *CertificateService) GetRenewalInfo(certID string) (*http.Response, error) {
+	if c.core.GetDirectory().RenewalInfo == "" {
+		return nil, ErrNoARI
+	}
 	if certID == "" {
 		return nil, errors.New("renewalInfo[post]: 'certID' cannot be empty")
 	}
@@ -74,7 +87,16 @@ func (c *CertificateService) GetRenewalInfo(certID string) (*http.Response, erro
 // PostRenewalInfo POSTs updated renewal information for a certificate to the
 // renewalInfo endpoint. This is used to indicate that a certificate has been
 // renewed.
+//
+// Note: this endpoint is part of a draft specification, not all ACME servers
+// will implement it. This method will return api.ErrNoARI if the server does
+// not advertise a renewal info endpoint.
+//
+// https://datatracker.ietf.org/doc/draft-ietf-acme-ari
 func (c *CertificateService) UpdateRenewalInfo(req acme.RenewalInfoUpdateRequest) (*http.Response, error) {
+	if c.core.GetDirectory().RenewalInfo == "" {
+		return nil, ErrNoARI
+	}
 	if req.CertID == "" {
 		return nil, errors.New("renewalInfo[post]: 'certID' cannot be empty")
 	}

--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -84,7 +84,7 @@ func (c *CertificateService) GetRenewalInfo(certID string) (*http.Response, erro
 	return c.core.HTTPClient.Get(c.core.GetDirectory().RenewalInfo + "/" + certID)
 }
 
-// PostRenewalInfo POSTs updated renewal information for a certificate to the
+// UpdateRenewalInfo POSTs updated renewal information for a certificate to the
 // renewalInfo endpoint. This is used to indicate that a certificate has been
 // replaced.
 //

--- a/acme/api/certificate.go
+++ b/acme/api/certificate.go
@@ -86,7 +86,7 @@ func (c *CertificateService) GetRenewalInfo(certID string) (*http.Response, erro
 
 // PostRenewalInfo POSTs updated renewal information for a certificate to the
 // renewalInfo endpoint. This is used to indicate that a certificate has been
-// renewed.
+// replaced.
 //
 // Note: this endpoint is part of a draft specification, not all ACME servers
 // will implement it. This method will return api.ErrNoARI if the server does

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -317,7 +317,7 @@ type Window struct {
 
 // RenewalInfoResponse is the response to GET requests made the renewalInfo
 // endpoint.
-// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ (4.1.  Getting Renewal Information)
+// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ (4.1.  Getting Renewal Information).
 type RenewalInfoResponse struct {
 	// SuggestedWindow contains two fields, start and end, whose values are
 	// timestamps which bound the window of time in which the CA recommends renewing
@@ -333,7 +333,7 @@ type RenewalInfoResponse struct {
 
 // RenewalInfoUpdateRequest is the JWS payload for POST requests made to the
 // renewalInfo endpoint.
-// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ (4.2.  Updating Renewal Information)
+// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ (4.2.  Updating Renewal Information).
 type RenewalInfoUpdateRequest struct {
 	// CertID is the base64url-encoded [RFC4648] bytes of a DER-encoded CertID
 	// ASN.1 sequence [RFC6960] with any trailing '=' characters stripped.

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -332,7 +332,7 @@ type RenewalInfoResponse struct {
 
 // RenewalInfoUpdateRequest is the JWS payload for POST requests made to the
 // renewalInfo endpoint.
-// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ 4.2.  Updating Renewal Information)
+// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ (4.2.  Updating Renewal Information)
 type RenewalInfoUpdateRequest struct {
 	// CertID is the base64url-encoded [RFC4648] bytes of a DER-encoded CertID
 	// ASN.1 sequence [RFC6960] with any trailing '=' characters stripped.

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -46,6 +46,7 @@ type Directory struct {
 	RevokeCertURL string `json:"revokeCert"`
 	KeyChangeURL  string `json:"keyChange"`
 	Meta          Meta   `json:"meta"`
+	RenewalInfo   string `json:"renewalInfo"`
 }
 
 // Meta the ACME meta object (related to Directory).

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -307,3 +307,41 @@ type RawCertificate struct {
 	Cert   []byte
 	Issuer []byte
 }
+
+// Window is a window of time.
+type Window struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// RenewalInfoResponse is the response to GET requests made the renewalInfo
+// endpoint.
+// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ (4.1.  Getting Renewal Information)
+type RenewalInfoResponse struct {
+	// SuggestedWindow contains two fields, start and end, whose values are
+	// timestamps which bound the window of time in which the CA recommends renewing
+	// the certificate.
+	SuggestedWindow Window `json:"suggestedWindow"`
+	//	ExplanationURL is a optional URL pointing to a page which may explain
+	//	why the suggested renewal window is what it is. For example, it may be a
+	//	page explaining the CA's dynamic load-balancing strategy, or a page
+	//	documenting which certificates are affected by a mass revocation event.
+	//	Callers SHOULD provide this URL to their operator, if present.
+	ExplanationURL string `json:"explanationUrl"`
+}
+
+// RenewalInfoUpdateRequest is the JWS payload for POST requests made to the
+// renewalInfo endpoint.
+// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/ 4.2.  Updating Renewal Information)
+type RenewalInfoUpdateRequest struct {
+	// CertID is the base64url-encoded [RFC4648] bytes of a DER-encoded CertID
+	// ASN.1 sequence [RFC6960] with any trailing '=' characters stripped.
+	CertID string `json:"certID"`
+	// Replaced is required and indicates whether or not the client considers
+	// the certificate to have been replaced.  A certificate is considered
+	// replaced when its revocation would not disrupt any ongoing services, for
+	// instance because it has been renewed and the new certificate is in use,
+	// or because it is no longer in use.  Clients SHOULD NOT send a request
+	// where this value is false.
+	Replaced bool `json:"replaced"`
+}

--- a/acme/commons.go
+++ b/acme/commons.go
@@ -38,6 +38,7 @@ const (
 
 // Directory the ACME directory object.
 // - https://www.rfc-editor.org/rfc/rfc8555.html#section-7.1.1
+// - https://datatracker.ietf.org/doc/draft-ietf-acme-ari/
 type Directory struct {
 	NewNonceURL   string `json:"newNonce"`
 	NewAccountURL string `json:"newAccount"`

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -97,7 +97,8 @@ type RenewalInfoResponse struct {
 // It returns a pointer to a time.Time value indicating when the renewal should
 // be attempted or nil if deferred until the next normal wake time. This method
 // implements the RECOMMENDED algorithm described in draft-ietf-acme-ari.
-//  (4.1-11. Getting Renewal Information)
+//
+//	(4.1-11. Getting Renewal Information)
 func (r *RenewalInfoResponse) ShouldRenewAt(now time.Time, willingToSleep time.Duration) *time.Time {
 	// Explicitly convert all times to UTC.
 	now = now.UTC()
@@ -659,18 +660,14 @@ func (c *Certifier) UpdateRenewalInfo(req RenewalInfoRequest) error {
 		return fmt.Errorf("error making certID: %v", err)
 	}
 
-	resp, err := c.core.Certificates.UpdateRenewalInfo(acme.RenewalInfoUpdateRequest{
+	_, err = c.core.Certificates.UpdateRenewalInfo(acme.RenewalInfoUpdateRequest{
 		CertID:   certID,
 		Replaced: true,
 	})
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
-	}
 	return nil
 }
 

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -719,6 +719,13 @@ func sanitizeDomain(domains []string) []string {
 // certificate to endpoints that implement the draft-ietf-acme-ari
 // specification: https://datatracker.ietf.org/doc/draft-ietf-acme-ari
 func makeCertID(leaf, issuer *x509.Certificate) (string, error) {
+	if leaf == nil {
+		return "", fmt.Errorf("leaf certificate is nil")
+	}
+	if issuer == nil {
+		return "", fmt.Errorf("issuer certificate is nil")
+	}
+
 	var hashFunc crypto.Hash
 	var oid asn1.ObjectIdentifier
 

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -80,6 +80,54 @@ type ObtainForCSRRequest struct {
 	AlwaysDeactivateAuthorizations bool
 }
 
+// RenewalInfoRequest contains the necessary renewal information.
+type RenewalInfoRequest struct {
+	Cert   *x509.Certificate
+	Issuer *x509.Certificate
+}
+
+// RenewalInfoResponse is a wrapper around acme.RenewalInfoResponse that provides a
+// method for determining when to renew a certificate.
+type RenewalInfoResponse struct {
+	acme.RenewalInfoResponse
+}
+
+// ShouldRenewAt determines the optimal renewal time based on the current time
+// (UTC), renewal window suggest by ARI, and the client's willingness to sleep.
+// It returns a pointer to a time.Time value indicating when the renewal should
+// be attempted or nil if deferred until the next normal wake time. This method
+// implements the RECOMMENDED algorithm described in draft-ietf-acme-ari.
+func (r *RenewalInfoResponse) ShouldRenewAt(now time.Time, willingToSleep time.Duration) *time.Time {
+	// Explicitly convert all times to UTC.
+	now = now.UTC()
+	start := r.SuggestedWindow.Start.UTC()
+	end := r.SuggestedWindow.End.UTC()
+
+	// Select a uniform random time within the suggested window.
+	window := end.Sub(start)
+	randomDuration := time.Duration(rand.Int63n(int64(window)))
+	rt := start.Add(randomDuration)
+
+	// If the selected time is in the past, attempt renewal immediately.
+	if rt.Before(now) {
+		return &now
+	}
+
+	// Otherwise, if the client can schedule itself to attempt renewal at
+	// exactly the selected time, do so.
+	willingToSleepUntil := now.Add(willingToSleep)
+	if willingToSleepUntil.After(rt) || willingToSleepUntil.Equal(rt) {
+		return &rt
+	}
+
+	// TODO: Otherwise, if the selected time is before the next time that the
+	// client would wake up normally, attempt renewal immediately.
+
+	// Otherwise, sleep until the next normal wake time, re-check ARI, and
+	// return to Step 1.
+	return nil
+}
+
 type resolver interface {
 	Solve(authorizations []acme.Authorization) error
 }
@@ -562,66 +610,18 @@ func (c *Certifier) Get(url string, bundle bool) (*Resource, error) {
 	}, nil
 }
 
-// RenewalInfoRequest contains the necessary renewal information.
-type RenewalInfoRequest struct {
-	Cert   *x509.Certificate
-	Issuer *x509.Certificate
-}
-
-// RenewalInfo is a wrapper around acme.RenewalInfoResponse that provides a
-// method for determining when to renew a certificate.
-type RenewalInfo struct {
-	acme.RenewalInfoResponse
-}
-
-// ShouldRenewAt determines the optimal renewal time based on the current time
-// (UTC), renewal window suggest by ARI, and the client's willingness to sleep.
-// It returns a pointer to a time.Time value indicating when the renewal should
-// be attempted or nil if deferred until the next normal wake time. This method
-// implements the RECOMMENDED algorithm described in draft-ietf-acme-ari.
-func (r *RenewalInfo) ShouldRenewAt(now time.Time, willingToSleep time.Duration) *time.Time {
-	// Explicitly convert all times to UTC.
-	now = now.UTC()
-	start := r.SuggestedWindow.Start.UTC()
-	end := r.SuggestedWindow.End.UTC()
-
-	// Select a uniform random time within the suggested window.
-	window := end.Sub(start)
-	randomDuration := time.Duration(rand.Int63n(int64(window)))
-	rt := start.Add(randomDuration)
-
-	// If the selected time is in the past, attempt renewal immediately.
-	if rt.Before(now) {
-		return &now
-	}
-
-	// Otherwise, if the client can schedule itself to attempt renewal at
-	// exactly the selected time, do so.
-	willingToSleepUntil := now.Add(willingToSleep)
-	if willingToSleepUntil.After(rt) || willingToSleepUntil.Equal(rt) {
-		return &rt
-	}
-
-	// TODO: Otherwise, if the selected time is before the next time that the
-	// client would wake up normally, attempt renewal immediately.
-
-	// Otherwise, sleep until the next normal wake time, re-check ARI, and
-	// return to Step 1.
-	return nil
-}
-
 // GetRenewalInfo sends a request to the ACME server's renewalInfo endpoint to
 // obtain a suggested renewal window. The caller MUST provide the certificate
 // and issuer certificate for the certificate they wish to renew. The caller
 // should attempt to renew the certificate at the time indicated by the
-// ShouldRenewAt method of the returned RenewalInfo object.
+// ShouldRenewAt method of the returned RenewalInfoResponse object.
 //
 // Note: this endpoint is part of a draft specification, not all ACME servers
 // will implement it. This method will return api.ErrNoARI if the server does
 // not advertise a renewal info endpoint.
 //
 // https://datatracker.ietf.org/doc/draft-ietf-acme-ari
-func (c *Certifier) GetRenewalInfo(req RenewalInfoRequest) (*RenewalInfo, error) {
+func (c *Certifier) GetRenewalInfo(req RenewalInfoRequest) (*RenewalInfoResponse, error) {
 	certID, err := makeCertID(req.Cert, req.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("error making certID: %v", err)
@@ -633,7 +633,7 @@ func (c *Certifier) GetRenewalInfo(req RenewalInfoRequest) (*RenewalInfo, error)
 	}
 	defer resp.Body.Close()
 
-	var info RenewalInfo
+	var info RenewalInfoResponse
 	err = json.NewDecoder(resp.Body).Decode(&info)
 	if err != nil {
 		return nil, err

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -761,7 +761,6 @@ func makeCertID(leaf, issuer *x509.Certificate, hashName string) (string, error)
 		return "", fmt.Errorf("hashName %q is not supported by this package", hashName)
 	}
 
-	// Check that the hash function is available on this platform.
 	if !hashFunc.Available() {
 		// This should never happen.
 		return "", fmt.Errorf("hash function %q is not available on your platform", hashFunc)

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -97,6 +97,7 @@ type RenewalInfoResponse struct {
 // It returns a pointer to a time.Time value indicating when the renewal should
 // be attempted or nil if deferred until the next normal wake time. This method
 // implements the RECOMMENDED algorithm described in draft-ietf-acme-ari.
+//  (4.1-11. Getting Renewal Information)
 func (r *RenewalInfoResponse) ShouldRenewAt(now time.Time, willingToSleep time.Duration) *time.Time {
 	// Explicitly convert all times to UTC.
 	now = now.UTC()

--- a/certificate/certificates.go
+++ b/certificate/certificates.go
@@ -84,6 +84,11 @@ type ObtainForCSRRequest struct {
 type RenewalInfoRequest struct {
 	Cert   *x509.Certificate
 	Issuer *x509.Certificate
+	// HashName must be the string representation of a crypto.Hash constant in
+	// the golang.org/x/crypto package (e.g. "SHA-256"). The correct value
+	// depends on the algorithm expected by the ACME server's ARI
+	// implementation.
+	HashName string
 }
 
 // RenewalInfoResponse is a wrapper around acme.RenewalInfoResponse that provides a
@@ -624,7 +629,7 @@ func (c *Certifier) Get(url string, bundle bool) (*Resource, error) {
 //
 // https://datatracker.ietf.org/doc/draft-ietf-acme-ari
 func (c *Certifier) GetRenewalInfo(req RenewalInfoRequest) (*RenewalInfoResponse, error) {
-	certID, err := makeCertID(req.Cert, req.Issuer)
+	certID, err := makeCertID(req.Cert, req.Issuer, req.HashName)
 	if err != nil {
 		return nil, fmt.Errorf("error making certID: %v", err)
 	}
@@ -655,7 +660,7 @@ func (c *Certifier) GetRenewalInfo(req RenewalInfoRequest) (*RenewalInfoResponse
 //
 // https://datatracker.ietf.org/doc/draft-ietf-acme-ari
 func (c *Certifier) UpdateRenewalInfo(req RenewalInfoRequest) error {
-	certID, err := makeCertID(req.Cert, req.Issuer)
+	certID, err := makeCertID(req.Cert, req.Issuer, req.HashName)
 	if err != nil {
 		return fmt.Errorf("error making certID: %v", err)
 	}
@@ -717,8 +722,11 @@ func sanitizeDomain(domains []string) []string {
 
 // makeCertID returns a base64url-encoded string that uniquely identifies a
 // certificate to endpoints that implement the draft-ietf-acme-ari
-// specification: https://datatracker.ietf.org/doc/draft-ietf-acme-ari
-func makeCertID(leaf, issuer *x509.Certificate) (string, error) {
+// specification: https://datatracker.ietf.org/doc/draft-ietf-acme-ari. hashName
+// must be the string representation of a crypto.Hash constant in the
+// golang.org/x/crypto package. Supported hash functions are SHA-1, SHA-256,
+// SHA-384, and SHA-512.
+func makeCertID(leaf, issuer *x509.Certificate, hashName string) (string, error) {
 	if leaf == nil {
 		return "", fmt.Errorf("leaf certificate is nil")
 	}
@@ -729,34 +737,34 @@ func makeCertID(leaf, issuer *x509.Certificate) (string, error) {
 	var hashFunc crypto.Hash
 	var oid asn1.ObjectIdentifier
 
-	switch issuer.SignatureAlgorithm {
-	// The following correlation of hash to hashFunc and OID is copied from a
-	// private mapping in golang.org/x/crypto/ocsp:
+	switch hashName {
+	// The following correlation of hashFunc to OID is copied from a private
+	// mapping in golang.org/x/crypto/ocsp:
 	// https://cs.opensource.google/go/x/crypto/+/refs/tags/v0.8.0:ocsp/ocsp.go;l=156
-	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
+	case crypto.SHA1.String():
 		hashFunc = crypto.SHA1
 		oid = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
 
-	case x509.SHA256WithRSA, x509.ECDSAWithSHA256:
+	case crypto.SHA256.String():
 		hashFunc = crypto.SHA256
 		oid = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 1})
 
-	case x509.SHA384WithRSA, x509.ECDSAWithSHA384:
+	case crypto.SHA384.String():
 		hashFunc = crypto.SHA384
 		oid = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 2})
 
-	case x509.SHA512WithRSA, x509.ECDSAWithSHA512:
+	case crypto.SHA512.String():
 		hashFunc = crypto.SHA512
 		oid = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 3})
 
 	default:
-		return "", fmt.Errorf("unsupported signature algorithm %s", issuer.SignatureAlgorithm)
+		return "", fmt.Errorf("hashName %q is not supported by this package", hashName)
 	}
 
 	// Check that the hash function is available on this platform.
 	if !hashFunc.Available() {
 		// This should never happen.
-		return "", fmt.Errorf("unsupported hash function %s", hashFunc)
+		return "", fmt.Errorf("hash function %q is not available on your platform", hashFunc)
 	}
 
 	var spki struct {

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -1,6 +1,7 @@
 package certificate
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -447,7 +448,6 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 )
 
 func Test_makeCertID(t *testing.T) {
-
 	leafBlock, _ := pem.Decode([]byte(ariLeafPEM))
 	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
 	require.NoError(t, err)
@@ -455,7 +455,7 @@ func Test_makeCertID(t *testing.T) {
 	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
 	require.NoError(t, err)
 
-	actual, err := makeCertID(leaf, issuer)
+	actual, err := makeCertID(leaf, issuer, crypto.SHA256.String())
 	require.NoError(t, err)
 	assert.Equal(t, ariLeafCertID, actual)
 }
@@ -493,7 +493,7 @@ func TestGetRenewalInfo(t *testing.T) {
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
-	ri, err := certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	ri, err := certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer, crypto.SHA256.String()})
 	require.NoError(t, err)
 	require.NotNil(t, ri)
 	assert.Equal(t, "2020-03-17T17:51:09Z", ri.SuggestedWindow.Start.Format(time.RFC3339))
@@ -524,7 +524,7 @@ func TestGetRenewalInfoError(t *testing.T) {
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
-	ri, err := certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	ri, err := certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer, crypto.SHA256.String()})
 	require.Error(t, err)
 	assert.Nil(t, ri)
 
@@ -539,15 +539,11 @@ func TestGetRenewalInfoError(t *testing.T) {
 
 	certifier = NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
-	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer, crypto.SHA256.String()})
 	require.Error(t, err)
 	assert.Nil(t, ri)
 
-	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{leaf, nil})
-	require.Error(t, err)
-	assert.Nil(t, ri)
-
-	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{nil, issuer})
+	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{leaf, nil, crypto.SHA256.String()})
 	require.Error(t, err)
 	assert.Nil(t, ri)
 }
@@ -630,7 +626,7 @@ func TestUpdateRenewalInfo(t *testing.T) {
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
-	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, issuer, crypto.SHA256.String()})
 	require.NoError(t, err)
 }
 
@@ -657,13 +653,10 @@ func TestUpdateRenewalInfoError(t *testing.T) {
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
-	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, issuer, crypto.SHA256.String()})
 	require.Error(t, err)
 
-	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{nil, issuer})
-	require.Error(t, err)
-
-	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, nil})
+	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{nil, issuer, crypto.SHA256.String()})
 	require.Error(t, err)
 }
 

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -531,6 +531,7 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 
 	ri, err := certifier.RetrieveRenewalInfo(CheckRenewalInfoRequest{leaf, issuer})
 	require.NoError(t, err)
+	require.NotNil(t, ri)
 	assert.Equal(t, "2020-03-17T17:51:09Z", ri.SuggestedWindow.Start.Format(time.RFC3339))
 	assert.Equal(t, "2020-03-17T18:21:09Z", ri.SuggestedWindow.End.Format(time.RFC3339))
 	assert.Equal(t, "https://aricapable.ca/docs/renewal-advice/", ri.ExplanationURL)

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -454,6 +454,88 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 	assert.Equal(t, expected, actual)
 }
 
+func TestRetrieveRenewalInfo(t *testing.T) {
+	leafPEM := `-----BEGIN CERTIFICATE-----
+MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
+NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
+OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
+3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
+HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
+vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
+vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
+DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
+AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
+DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
++hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
+EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
+TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
+1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
+HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
+o9q12g==
+-----END CERTIFICATE-----`
+	issuerPEM := `-----BEGIN CERTIFICATE-----
+MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
+MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
+IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
+TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
+zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
+c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
+kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
+AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
+BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
+STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
+hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
+1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
+ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
+Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
+fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
+QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
+-----END CERTIFICATE-----`
+	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
+	require.NoError(t, err)
+	issuerBlock, _ := pem.Decode([]byte(issuerPEM))
+	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
+	require.NoError(t, err)
+
+	leafCertID := "MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGHeZ7pTS8jYCCD6jRWhlRB8c"
+
+	// Test with a fake API.
+	mux, apiURL := tester.SetupFakeAPI(t)
+	mux.HandleFunc("/renewalInfo/"+leafCertID, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+				"suggestedWindow": {
+					"start": "2020-03-17T17:51:09Z",
+					"end": "2020-03-17T18:21:09Z"
+				},
+				"explanationUrl": "https://aricapable.ca/docs/renewal-advice/"
+			}
+		}`))
+		require.NoError(t, err)
+	})
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Could not generate test key")
+
+	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", key)
+	require.NoError(t, err)
+
+	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
+
+	ri, err := certifier.RetrieveRenewalInfo(CheckRenewalInfoRequest{leaf, issuer})
+	require.NoError(t, err)
+	assert.Equal(t, "2020-03-17T17:51:09Z", ri.SuggestedWindow.Start.Format(time.RFC3339))
+	assert.Equal(t, "2020-03-17T18:21:09Z", ri.SuggestedWindow.End.Format(time.RFC3339))
+	assert.Equal(t, "https://aricapable.ca/docs/renewal-advice/", ri.ExplanationURL)
+}
+
 func TestRenewalInfo_ShouldRenew(t *testing.T) {
 	now := time.Now().UTC()
 

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -664,6 +664,73 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 	require.NoError(t, err)
 }
 
+func TestUpdateRenewalInfoError(t *testing.T) {
+	leafPEM := `-----BEGIN CERTIFICATE-----
+MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
+NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
+OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
+3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
+HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
+vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
+vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
+DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
+AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
+DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
++hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
+EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
+TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
+1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
+HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
+o9q12g==
+-----END CERTIFICATE-----`
+	issuerPEM := `-----BEGIN CERTIFICATE-----
+MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
+MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
+IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
+TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
+zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
+c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
+kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
+AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
+BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
+STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
+hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
+1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
+ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
+Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
+fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
+QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
+-----END CERTIFICATE-----`
+	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
+	require.NoError(t, err)
+	issuerBlock, _ := pem.Decode([]byte(issuerPEM))
+	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
+	require.NoError(t, err)
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Could not generate test key")
+
+	// Test with a fake API.
+	mux, apiURL := tester.SetupFakeAPI(t)
+	// Always returns an error.
+	mux.HandleFunc("/renewalInfo", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+	})
+
+	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", key)
+	require.NoError(t, err)
+
+	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
+
+	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	require.Error(t, err)
+}
+
 func readSignedBody(r *http.Request, privateKey *rsa.PrivateKey) ([]byte, error) {
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -529,7 +529,7 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
-	ri, err := certifier.RetrieveRenewalInfo(CheckRenewalInfoRequest{leaf, issuer})
+	ri, err := certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer})
 	require.NoError(t, err)
 	require.NotNil(t, ri)
 	assert.Equal(t, "2020-03-17T17:51:09Z", ri.SuggestedWindow.Start.Format(time.RFC3339))
@@ -542,22 +542,26 @@ func TestRenewalInfo_ShouldRenew(t *testing.T) {
 
 	// Window is in the past.
 	ri := RenewalInfo{
-		SuggestedWindow{
-			Start: now.Add(-1 * time.Hour),
-			End:   now.Add(-30 * time.Minute),
+		acme.RenewalInfoResponse{
+			SuggestedWindow: acme.Window{
+				Start: now.Add(-2 * time.Hour),
+				End:   now.Add(-1 * time.Hour),
+			},
+			ExplanationURL: "",
 		},
-		"",
 	}
 	rt := ri.ShouldRenewAt(now, 0)
 	assert.Equal(t, now, *rt)
 
 	// Window is in the future.
 	ri = RenewalInfo{
-		SuggestedWindow{
-			Start: now.Add(1 * time.Hour),
-			End:   now.Add(2 * time.Hour),
+		acme.RenewalInfoResponse{
+			SuggestedWindow: acme.Window{
+				Start: now.Add(1 * time.Hour),
+				End:   now.Add(2 * time.Hour),
+			},
+			ExplanationURL: "",
 		},
-		"",
 	}
 	rt = ri.ShouldRenewAt(now, 0)
 	assert.Nil(t, rt)

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -402,8 +402,8 @@ func (r *resolverMock) Solve(_ []acme.Authorization) error {
 	return r.error
 }
 
-func Test_makeCertID(t *testing.T) {
-	leafPEM := `-----BEGIN CERTIFICATE-----
+const (
+	ariLeafPEM = `-----BEGIN CERTIFICATE-----
 MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
 NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
@@ -423,7 +423,7 @@ TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
 HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
 o9q12g==
 -----END CERTIFICATE-----`
-	issuerPEM := `-----BEGIN CERTIFICATE-----
+	ariIssuerPEM = `-----BEGIN CERTIFICATE-----
 MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
 MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
@@ -443,73 +443,34 @@ Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
 fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
 QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 -----END CERTIFICATE-----`
-	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	ariLeafCertID = "MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGHeZ7pTS8jYCCD6jRWhlRB8c"
+)
+
+func Test_makeCertID(t *testing.T) {
+
+	leafBlock, _ := pem.Decode([]byte(ariLeafPEM))
 	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
 	require.NoError(t, err)
-	issuerBlock, _ := pem.Decode([]byte(issuerPEM))
+	issuerBlock, _ := pem.Decode([]byte(ariIssuerPEM))
 	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
 	require.NoError(t, err)
 
 	actual, err := makeCertID(leaf, issuer)
 	require.NoError(t, err)
-
-	expected := "MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGHeZ7pTS8jYCCD6jRWhlRB8c"
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, ariLeafCertID, actual)
 }
 
 func TestGetRenewalInfo(t *testing.T) {
-	leafPEM := `-----BEGIN CERTIFICATE-----
-MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
-NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
-AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
-OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
-3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
-HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
-vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
-vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
-DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
-AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
-DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
-+hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
-EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
-TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
-1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
-HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
-o9q12g==
------END CERTIFICATE-----`
-	issuerPEM := `-----BEGIN CERTIFICATE-----
-MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
-MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
-MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
-IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
-TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
-zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
-c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
-kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
-AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
-BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
-STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
-hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
-1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
-ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
-Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
-fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
-QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
------END CERTIFICATE-----`
-	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	leafBlock, _ := pem.Decode([]byte(ariLeafPEM))
 	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
 	require.NoError(t, err)
-	issuerBlock, _ := pem.Decode([]byte(issuerPEM))
+	issuerBlock, _ := pem.Decode([]byte(ariIssuerPEM))
 	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
 	require.NoError(t, err)
 
-	leafCertID := "MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGHeZ7pTS8jYCCD6jRWhlRB8c"
-
 	// Test with a fake API.
 	mux, apiURL := tester.SetupFakeAPI(t)
-	mux.HandleFunc("/renewalInfo/"+leafCertID, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/renewalInfo/"+ariLeafCertID, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -538,6 +499,57 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 	assert.Equal(t, "2020-03-17T17:51:09Z", ri.SuggestedWindow.Start.Format(time.RFC3339))
 	assert.Equal(t, "2020-03-17T18:21:09Z", ri.SuggestedWindow.End.Format(time.RFC3339))
 	assert.Equal(t, "https://aricapable.ca/docs/renewal-advice/", ri.ExplanationURL)
+}
+
+func TestGetRenewalInfoError(t *testing.T) {
+	leafBlock, _ := pem.Decode([]byte(ariLeafPEM))
+	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
+	require.NoError(t, err)
+	issuerBlock, _ := pem.Decode([]byte(ariIssuerPEM))
+	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
+	require.NoError(t, err)
+
+	// API that takes 2ms to respond.
+	mux, apiURL := tester.SetupFakeAPI(t)
+	mux.HandleFunc("/renewalInfo/"+ariLeafCertID, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Millisecond)
+	})
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Could not generate test key")
+
+	// HTTP client that times out after 1ms.
+	core, err := api.New(&http.Client{Timeout: 1 * time.Millisecond}, "lego-test", apiURL+"/dir", "", key)
+	require.NoError(t, err)
+
+	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
+
+	ri, err := certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	require.Error(t, err)
+	assert.Nil(t, ri)
+
+	// API that responds with error instead of renewal info.
+	mux, apiURL = tester.SetupFakeAPI(t)
+	mux.HandleFunc("/renewalInfo/"+ariLeafCertID, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+	})
+
+	core, err = api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", key)
+	require.NoError(t, err)
+
+	certifier = NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
+
+	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	require.Error(t, err)
+	assert.Nil(t, ri)
+
+	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{leaf, nil})
+	require.Error(t, err)
+	assert.Nil(t, ri)
+
+	ri, err = certifier.GetRenewalInfo(RenewalInfoRequest{nil, issuer})
+	require.Error(t, err)
+	assert.Nil(t, ri)
 }
 
 func TestRenewalInfo_ShouldRenew(t *testing.T) {
@@ -580,54 +592,12 @@ func TestRenewalInfo_ShouldRenew(t *testing.T) {
 }
 
 func TestUpdateRenewalInfo(t *testing.T) {
-	leafPEM := `-----BEGIN CERTIFICATE-----
-MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
-NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
-AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
-OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
-3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
-HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
-vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
-vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
-DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
-AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
-DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
-+hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
-EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
-TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
-1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
-HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
-o9q12g==
------END CERTIFICATE-----`
-	issuerPEM := `-----BEGIN CERTIFICATE-----
-MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
-MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
-MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
-IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
-TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
-zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
-c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
-kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
-AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
-BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
-STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
-hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
-1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
-ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
-Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
-fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
-QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
------END CERTIFICATE-----`
-	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	leafBlock, _ := pem.Decode([]byte(ariLeafPEM))
 	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
 	require.NoError(t, err)
-	issuerBlock, _ := pem.Decode([]byte(issuerPEM))
+	issuerBlock, _ := pem.Decode([]byte(ariIssuerPEM))
 	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
 	require.NoError(t, err)
-
-	leafCertID := "MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGHeZ7pTS8jYCCD6jRWhlRB8c"
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Could not generate test key")
@@ -650,7 +620,7 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 		err = json.Unmarshal(body, &req)
 		assert.NoError(t, err)
 		assert.True(t, req.Replaced)
-		assert.Equal(t, leafCertID, req.CertID)
+		assert.Equal(t, ariLeafCertID, req.CertID)
 
 		w.WriteHeader(http.StatusOK)
 	})
@@ -665,50 +635,10 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 }
 
 func TestUpdateRenewalInfoError(t *testing.T) {
-	leafPEM := `-----BEGIN CERTIFICATE-----
-MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
-NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
-AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
-OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
-3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
-HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
-vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
-vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
-DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
-AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
-DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
-+hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
-EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
-TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
-1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
-HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
-o9q12g==
------END CERTIFICATE-----`
-	issuerPEM := `-----BEGIN CERTIFICATE-----
-MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
-MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
-MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
-IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
-TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
-zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
-c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
-kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
-AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
-BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
-STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
-hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
-1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
-ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
-Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
-fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
-QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
------END CERTIFICATE-----`
-	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	leafBlock, _ := pem.Decode([]byte(ariLeafPEM))
 	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
 	require.NoError(t, err)
-	issuerBlock, _ := pem.Decode([]byte(issuerPEM))
+	issuerBlock, _ := pem.Decode([]byte(ariIssuerPEM))
 	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
 	require.NoError(t, err)
 
@@ -728,6 +658,12 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
 
 	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	require.Error(t, err)
+
+	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{nil, issuer})
+	require.Error(t, err)
+
+	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, nil})
 	require.Error(t, err)
 }
 

--- a/certificate/certificates_test.go
+++ b/certificate/certificates_test.go
@@ -4,8 +4,10 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -14,6 +16,7 @@ import (
 	"github.com/go-acme/lego/v4/acme/api"
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/platform/tester"
+	"github.com/go-jose/go-jose/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -454,7 +457,7 @@ QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
 	assert.Equal(t, expected, actual)
 }
 
-func TestRetrieveRenewalInfo(t *testing.T) {
+func TestGetRenewalInfo(t *testing.T) {
 	leafPEM := `-----BEGIN CERTIFICATE-----
 MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
@@ -541,7 +544,7 @@ func TestRenewalInfo_ShouldRenew(t *testing.T) {
 	now := time.Now().UTC()
 
 	// Window is in the past.
-	ri := RenewalInfo{
+	ri := RenewalInfoResponse{
 		acme.RenewalInfoResponse{
 			SuggestedWindow: acme.Window{
 				Start: now.Add(-2 * time.Hour),
@@ -554,7 +557,7 @@ func TestRenewalInfo_ShouldRenew(t *testing.T) {
 	assert.Equal(t, now, *rt)
 
 	// Window is in the future.
-	ri = RenewalInfo{
+	ri = RenewalInfoResponse{
 		acme.RenewalInfoResponse{
 			SuggestedWindow: acme.Window{
 				Start: now.Add(1 * time.Hour),
@@ -574,4 +577,88 @@ func TestRenewalInfo_ShouldRenew(t *testing.T) {
 	// Window is in the future, but caller isn't willing to sleep long enough.
 	rt = ri.ShouldRenewAt(now, 59*time.Minute)
 	assert.Nil(t, rt)
+}
+
+func TestUpdateRenewalInfo(t *testing.T) {
+	leafPEM := `-----BEGIN CERTIFICATE-----
+MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
+NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
+OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
+3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
+HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
+vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
+vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
+DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
+AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
+DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
++hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
+EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
+TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
+1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
+HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
+o9q12g==
+-----END CERTIFICATE-----`
+	issuerPEM := `-----BEGIN CERTIFICATE-----
+MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
+MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
+IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
+TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
+zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
+c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
+kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
+AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
+BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
+STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
+hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
+1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
+ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
+Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
+fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
+QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
+-----END CERTIFICATE-----`
+	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	leaf, err := x509.ParseCertificate(leafBlock.Bytes)
+	require.NoError(t, err)
+	issuerBlock, _ := pem.Decode([]byte(issuerPEM))
+	issuer, err := x509.ParseCertificate(issuerBlock.Bytes)
+	require.NoError(t, err)
+
+	leafCertID := "MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGHeZ7pTS8jYCCD6jRWhlRB8c"
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Could not generate test key")
+
+	// Test with a fake API.
+	mux, apiURL := tester.SetupFakeAPI(t)
+	mux.HandleFunc("/renewalInfo", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		reqBody, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		jws, err := jose.ParseSigned(string(reqBody))
+		assert.NoError(t, err)
+
+		payload, err := jws.Verify(key.Public())
+		assert.NoError(t, err)
+
+		var req acme.RenewalInfoUpdateRequest
+		err = json.Unmarshal(payload, &req)
+		assert.NoError(t, err)
+		assert.True(t, req.Replaced)
+		assert.Equal(t, leafCertID, req.CertID)
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	core, err := api.New(http.DefaultClient, "lego-test", apiURL+"/dir", "", key)
+	require.NoError(t, err)
+
+	certifier := NewCertifier(core, &resolverMock{}, CertifierOptions{KeyType: certcrypto.RSA2048})
+
+	err = certifier.UpdateRenewalInfo(RenewalInfoRequest{leaf, issuer})
+	require.NoError(t, err)
 }

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -53,6 +53,11 @@ func createRenew() *cli.Command {
 				Name:  "ari-enable",
 				Usage: "Use the renewalInfo endpoint (draft-ietf-acme-ari) to check if a certificate should be renewed.",
 			},
+			&cli.StringFlag{
+				Name:  "ari-hash-name",
+				Value: crypto.SHA256.String(),
+				Usage: "The string representation of the hash expected by the renewalInfo endpoint (e.g. \"SHA-256\").",
+			},
 			&cli.DurationFlag{
 				Name:  "ari-wait-to-renew-duration",
 				Usage: "The maximum duration you're willing to sleep for a renewal time returned by the renewalInfo endpoint.",
@@ -192,9 +197,9 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 		// Post to the renewalInfo endpoint to indicate that we have renewed and
 		// replaced the certificate.
 		err := client.Certificate.UpdateRenewalInfo(certificate.RenewalInfoRequest{
-			Cert:   certificates[0],
-			Issuer: certificates[1],
-		})
+			Cert:     certificates[0],
+			Issuer:   certificates[1],
+			HashName: ctx.String("ari-hash-name")})
 		if err != nil {
 			log.Warnf("[%s] Failed to update renewal info: %v", domain, err)
 		}
@@ -260,9 +265,9 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 		// Post to the renewalInfo endpoint to indicate that we have renewed and
 		// replaced the certificate.
 		err := client.Certificate.UpdateRenewalInfo(certificate.RenewalInfoRequest{
-			Cert:   certificates[0],
-			Issuer: certificates[1],
-		})
+			Cert:     certificates[0],
+			Issuer:   certificates[1],
+			HashName: ctx.String("ari-hash-name")})
 		if err != nil {
 			log.Warnf("[%s] Failed to update renewal info: %v", domain, err)
 		}
@@ -300,8 +305,9 @@ func needRenewalARI(ctx *cli.Context, cert, issuer *x509.Certificate, domain str
 	}
 
 	renewalInfo, err := client.Certificate.GetRenewalInfo(certificate.RenewalInfoRequest{
-		Cert:   cert,
-		Issuer: issuer})
+		Cert:     cert,
+		Issuer:   issuer,
+		HashName: ctx.String("ari-hash-name")})
 	if err != nil {
 		if errors.Is(err, api.ErrNoARI) {
 			// The server does not advertise a renewal info endpoint.

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -298,6 +298,10 @@ func needRenewalARI(ctx *cli.Context, cert, issuer *x509.Certificate, domain str
 	}
 	log.Infof("[%s] acme: renewalInfo endpoint indicates that renewal is needed", domain)
 
+	if renewalInfo.ExplanationURL != "" {
+		log.Infof("[%s] acme: renewalInfo endpoint provided an explanation: %s", domain, renewalInfo.ExplanationURL)
+	}
+
 	// Figure out if we need to sleep before renewing.
 	if renewalTime.After(now) {
 		log.Infof("[%s] Sleeping %s until renewal time %s", domain, renewalTime.Sub(now), renewalTime)

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-acme/lego/v4/acme/api"
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/certificate"
 	"github.com/go-acme/lego/v4/lego"
@@ -278,7 +279,7 @@ func needRenewalARI(ctx *cli.Context, cert, issuer *x509.Certificate, domain str
 		Cert:   cert,
 		Issuer: issuer})
 	if err != nil {
-		if errors.Is(err, certificate.ErrNoARIEndpoint) {
+		if errors.Is(err, api.ErrNoARI) {
 			// The server does not advertise a renewal info endpoint.
 			log.Warnf("[%s] acme: %w", domain, err)
 			return false

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -188,6 +188,18 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 
 	certsStorage.SaveResource(certRes)
 
+	if ariSaysRenew {
+		// Post to the renewalInfo endpoint to indicate that we have renewed and
+		// replaced the certificate.
+		err := client.Certificate.UpdateRenewalInfo(certificate.RenewalInfoRequest{
+			Cert:   certificates[0],
+			Issuer: certificates[1],
+		})
+		if err != nil {
+			log.Warnf("[%s] Failed to update renewal info: %v", domain, err)
+		}
+	}
+
 	meta[renewEnvCertDomain] = domain
 	meta[renewEnvCertPath] = certsStorage.GetFileName(domain, ".crt")
 	meta[renewEnvCertKeyPath] = certsStorage.GetFileName(domain, ".key")
@@ -243,6 +255,18 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 	}
 
 	certsStorage.SaveResource(certRes)
+
+	if ariSaysRenew {
+		// Post to the renewalInfo endpoint to indicate that we have renewed and
+		// replaced the certificate.
+		err := client.Certificate.UpdateRenewalInfo(certificate.RenewalInfoRequest{
+			Cert:   certificates[0],
+			Issuer: certificates[1],
+		})
+		if err != nil {
+			log.Warnf("[%s] Failed to update renewal info: %v", domain, err)
+		}
+	}
 
 	meta[renewEnvCertDomain] = domain
 	meta[renewEnvCertPath] = certsStorage.GetFileName(domain, ".crt")

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -132,8 +132,9 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 	if ctx.Bool("ari-enable") {
 		if len(certificates) < 2 {
 			log.Warnf("[%s] Certificate bundle does not contain issuer, cannot use the renewalInfo endpoint", domain)
+		} else {
+			ariSaysRenew = needRenewalARI(ctx, certificates[0], certificates[1], domain, client)
 		}
-		ariSaysRenew = needRenewalARI(ctx, certificates[0], certificates[1], domain, client)
 	}
 
 	if !ariSaysRenew && !needRenewal(cert, domain, ctx.Int("days")) {
@@ -217,8 +218,9 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 	if ctx.Bool("ari-enable") {
 		if len(certificates) < 2 {
 			log.Warnf("[%s] Certificate bundle does not contain issuer, cannot use the renewalInfo endpoint", domain)
+		} else {
+			ariSaysRenew = needRenewalARI(ctx, certificates[0], certificates[1], domain, client)
 		}
-		ariSaysRenew = needRenewalARI(ctx, certificates[0], certificates[1], domain, client)
 	}
 
 	if !ariSaysRenew && !needRenewal(cert, domain, ctx.Int("days")) {

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -274,11 +274,11 @@ func needRenewalARI(ctx *cli.Context, cert, issuer *x509.Certificate, domain str
 		log.Fatalf("[%s] Certificate bundle starts with a CA certificate", domain)
 	}
 
-	renewalInfo, err := client.Certificate.RetrieveRenewalInfo(certificate.CheckRenewalInfoRequest{
+	renewalInfo, err := client.Certificate.GetRenewalInfo(certificate.RenewalInfoRequest{
 		Cert:   cert,
 		Issuer: issuer})
 	if err != nil {
-		if errors.Is(err, certificate.ErrNoARI) {
+		if errors.Is(err, certificate.ErrNoARIEndpoint) {
 			// The server does not advertise a renewal info endpoint.
 			log.Warnf("[%s] acme: %w", domain, err)
 			return false

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -139,7 +139,7 @@ func renewForDomains(ctx *cli.Context, client *lego.Client, certsStorage *Certif
 		if len(certificates) < 2 {
 			log.Warnf("[%s] Certificate bundle does not contain issuer, cannot use the renewalInfo endpoint", domain)
 		} else {
-			ariRenewalTime = needRenewalARI(ctx, certificates[0], certificates[1], domain, client)
+			ariRenewalTime = getARIRenewalTime(ctx, certificates[0], certificates[1], domain, client)
 		}
 		if ariRenewalTime != nil {
 			now := time.Now().UTC()
@@ -245,7 +245,7 @@ func renewForCSR(ctx *cli.Context, client *lego.Client, certsStorage *Certificat
 		if len(certificates) < 2 {
 			log.Warnf("[%s] Certificate bundle does not contain issuer, cannot use the renewalInfo endpoint", domain)
 		} else {
-			ariRenewalTime = needRenewalARI(ctx, certificates[0], certificates[1], domain, client)
+			ariRenewalTime = getARIRenewalTime(ctx, certificates[0], certificates[1], domain, client)
 		}
 		if ariRenewalTime != nil {
 			now := time.Now().UTC()
@@ -313,9 +313,9 @@ func needRenewal(x509Cert *x509.Certificate, domain string, days int) bool {
 	return true
 }
 
-// needRenewalARI checks if the certificate needs to be renewed using the
+// getARIRenewalTime checks if the certificate needs to be renewed using the
 // renewalInfo endpoint.
-func needRenewalARI(ctx *cli.Context, cert, issuer *x509.Certificate, domain string, client *lego.Client) *time.Time {
+func getARIRenewalTime(ctx *cli.Context, cert, issuer *x509.Certificate, domain string, client *lego.Client) *time.Time {
 	if cert.IsCA {
 		log.Fatalf("[%s] Certificate bundle starts with a CA certificate", domain)
 	}

--- a/cmd/cmd_renew.go
+++ b/cmd/cmd_renew.go
@@ -54,7 +54,7 @@ func createRenew() *cli.Command {
 				Usage: "Use the renewalInfo endpoint (draft-ietf-acme-ari) to check if a certificate should be renewed.",
 			},
 			&cli.DurationFlag{
-				Name:  "ari-willing-to-sleep",
+				Name:  "ari-wait-to-renew-duration",
 				Usage: "The maximum duration you're willing to sleep for a renewal time returned by the renewalInfo endpoint.",
 			},
 			&cli.BoolFlag{
@@ -316,7 +316,7 @@ func needRenewalARI(ctx *cli.Context, cert, issuer *x509.Certificate, domain str
 	}
 
 	now := time.Now().UTC()
-	renewalTime := renewalInfo.ShouldRenewAt(now, ctx.Duration("ari-willing-to-sleep"))
+	renewalTime := renewalInfo.ShouldRenewAt(now, ctx.Duration("ari-wait-to-renew-duration"))
 	if renewalTime == nil {
 		log.Infof("[%s] acme: renewalInfo endpoint indicates that renewal is not needed", domain)
 		return false

--- a/platform/tester/api.go
+++ b/platform/tester/api.go
@@ -29,6 +29,7 @@ func SetupFakeAPI(t *testing.T) (*http.ServeMux, string) {
 			NewOrderURL:   server.URL + "/newOrder",
 			RevokeCertURL: server.URL + "/revokeCert",
 			KeyChangeURL:  server.URL + "/keyChange",
+			RenewalInfo:   server.URL + "/renewalInfo",
 		})
 
 		mux.HandleFunc("/nonce", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Additions to cmd/cmd_renew.go: 
- Optional flag `--ari-enable` to check the renewalInfo endpoint when evaluating whether a renewal is necessary and
- posting to the renewalInfo endpoint post-renewal to indicate that the certificate has been replaced. 
- Optional flag `--ari-willing-to-sleep` to indicate the duration you're willing to sleep for the renewal window suggested by the renewalInfo endpoint.

Additions to acme/api/certificate.go
- `CertificateService.GetRenewalInfo()` to support 4.1. Getting Renewal Information of draft-ietf-acme-ari-01
- `CertificateService.UpdateRenewalInfo()` to support 4.2. Updating Renewal Information of draft-ietf-acme-ari-01

Additions to acme/commons.go
- renewalInfo in Directory
- Various objects to support renewalInfo POST and GET

Additions to certificate/certificates.go
- Convenience methods to support renewalInfo Get and Update workflows in `cmd/cmd_renew.go`
- Function for deriving the CertID provided a certificate and issuer.